### PR TITLE
Fix charging controller software version check for BSM-WS36A

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 node_modules
 build/*.js
 dist
+src/build/*.js
 src/css/*.css
 src/css/*.css.map
 !src/css/fontawesome-all.min.css

--- a/documentation/chargeIT2/20220131-csc-version-data-forged.json
+++ b/documentation/chargeIT2/20220131-csc-version-data-forged.json
@@ -1,0 +1,428 @@
+            {
+  "placeInfo" : {
+    "geoLocation" : {
+      "lat" : 0.0,
+      "lon" : 0.0
+    },
+    "address" : {
+      "street" : "Steigweg 24, Gebäude 94",
+      "town" : "Kitzingen",
+      "zipCode" : "97318"
+    },
+    "evseId" : "DE*BDO*E323455206*2"
+  },
+  "signedMeterValues" : [{
+  "signature": "3046022100f14ad89d059bf780f8afe69eb73428c85474b47dd0cd6f9d26207d8dd4b0c0ed02210097f9a58d557d3feb2d84cb5036483c86cf08c9c20a1d38ce469861f8a0d346f8",
+  "contract": {
+    "id": "6ba608c2",
+    "type": "rfid"
+  },
+  "meterInfo": {
+    "meterId": "001BZR1521290137",
+    "publicKey": "3059301306072a8648ce3d020106082a8648ce3d03010703420004dab8d78e67621823a1542b0e60175f62b5ef3230cf8d0fa0d52724acdb11cfdaa9aa170c0ca271b5adbbb7ba83bde301f67d77bd5000caf568ad2f4960320ad8",
+    "firmwareVersion": "1.9:32CA:AFF4, 6d1dd3c",
+    "type": "BSM-WS36A-H01-1311-0000",
+    "manufacturer": "BAUER Electronic"
+  },
+  "@id": "001BZR1521290137-101",
+  "time": "2022-01-31T10:13:33+01:00",
+  "@context": "https://www.chargeit-mobility.com/contexts/bsm-ws36a-json-v1",
+  "measurementId": 101,
+  "value": {
+    "measurand": {
+      "name": "RCR",
+      "id": "1-0:1.8.0*198"
+    },
+    "measuredValue": {
+      "unit": "WATT_HOUR",
+      "unitEncoded": 30,
+      "valueType": "UnsignedInteger32",
+      "scale": 0,
+      "value": 0
+    }
+  },
+  "additionalValues": [
+    {
+      "measurand": {"name": "Typ"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 1
+      }
+    },
+    {
+      "measurand": {
+        "name": "RCR",
+        "id": "1-0:1.8.0*198"
+      },
+      "measuredValue": {
+        "unit": "WATT_HOUR",
+        "unitEncoded": 30,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 0
+      }
+    },
+    {
+      "measurand": {
+        "name": "TotWhImp",
+        "id": "1-0:1.8.0*255"
+      },
+      "measuredValue": {
+        "unit": "WATT_HOUR",
+        "unitEncoded": 30,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 7200
+      }
+    },
+    {
+      "measurand": {
+        "name": "W",
+        "id": "1-0:1.7.0*255"
+      },
+      "measuredValue": {
+        "unit": "WATT",
+        "unitEncoded": 27,
+        "valueType": "Integer32",
+        "scale": 1,
+        "value": 0
+      }
+    },
+    {
+      "measurand": {
+        "name": "MA1",
+        "id": "1-0:0.0.0*255"
+      },
+      "measuredValue": {
+        "valueType": "String",
+        "value": "001BZR1521290137",
+        "valueEncoding": "UTF-8"
+      }
+    },
+    {
+      "measurand": {"name": "RCnt"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 101
+      }
+    },
+    {
+      "measurand": {"name": "OS"},
+      "measuredValue": {
+        "unit": "SECOND",
+        "unitEncoded": 7,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 1378556
+      }
+    },
+    {
+      "measurand": {"name": "Epoch"},
+      "measuredValue": {
+        "unit": "SECOND",
+        "unitEncoded": 7,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 1643620413
+      }
+    },
+    {
+      "measurand": {"name": "TZO"},
+      "measuredValue": {
+        "unit": "MIN",
+        "unitEncoded": 6,
+        "valueType": "Integer32",
+        "scale": 0,
+        "value": 60
+      }
+    },
+    {
+      "measurand": {"name": "EpochSetCnt"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 106
+      }
+    },
+    {
+      "measurand": {"name": "EpochSetOS"},
+      "measuredValue": {
+        "unit": "SECOND",
+        "unitEncoded": 7,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 1377968
+      }
+    },
+    {
+      "measurand": {"name": "DI"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 1
+      }
+    },
+    {
+      "measurand": {"name": "DO"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 0
+      }
+    },
+    {
+      "measurand": {"name": "Meta1"},
+      "measuredValue": {
+        "valueType": "String",
+        "value": "contract-id: rfid:6ba608c2",
+        "valueEncoding": "UTF-8"
+      }
+    },
+    {
+      "measurand": {"name": "Meta2"},
+      "measuredValue": {
+        "valueType": "String",
+        "value": "",
+        "valueEncoding": "UTF-8"
+      }
+    },
+    {
+      "measurand": {"name": "Meta3"},
+      "measuredValue": {
+        "valueType": "String",
+        "value": "csc-sw-version: v0.3.0-10-gdeadbe",
+        "valueEncoding": "UTF-8"
+      }
+    },
+    {
+      "measurand": {"name": "Evt"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 0
+      }
+    }
+  ]
+}, {
+  "signature": "3045022055024952cccc23afcb4d0f24e75fa139486ca76c5969e680a2669ab611616bac022100fc1cff99ef5e95465a18dacafc141999085b96881395603623241415e2c42559",
+  "contract": {
+    "id": "6ba608c2",
+    "type": "rfid"
+  },
+  "meterInfo": {
+    "meterId": "001BZR1521290137",
+    "publicKey": "3059301306072a8648ce3d020106082a8648ce3d03010703420004dab8d78e67621823a1542b0e60175f62b5ef3230cf8d0fa0d52724acdb11cfdaa9aa170c0ca271b5adbbb7ba83bde301f67d77bd5000caf568ad2f4960320ad8",
+    "firmwareVersion": "1.9:32CA:AFF4, 6d1dd3c",
+    "type": "BSM-WS36A-H01-1311-0000",
+    "manufacturer": "BAUER Electronic"
+  },
+  "@id": "001BZR1521290137-102",
+  "time": "2022-01-31T10:14:47+01:00",
+  "@context": "https://www.chargeit-mobility.com/contexts/bsm-ws36a-json-v1",
+  "measurementId": 102,
+  "value": {
+    "measurand": {
+      "name": "RCR",
+      "id": "1-0:1.8.0*198"
+    },
+    "measuredValue": {
+      "unit": "WATT_HOUR",
+      "unitEncoded": 30,
+      "valueType": "UnsignedInteger32",
+      "scale": 0,
+      "value": 0
+    }
+  },
+  "additionalValues": [
+    {
+      "measurand": {"name": "Typ"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 2
+      }
+    },
+    {
+      "measurand": {
+        "name": "RCR",
+        "id": "1-0:1.8.0*198"
+      },
+      "measuredValue": {
+        "unit": "WATT_HOUR",
+        "unitEncoded": 30,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 0
+      }
+    },
+    {
+      "measurand": {
+        "name": "TotWhImp",
+        "id": "1-0:1.8.0*255"
+      },
+      "measuredValue": {
+        "unit": "WATT_HOUR",
+        "unitEncoded": 30,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 7200
+      }
+    },
+    {
+      "measurand": {
+        "name": "W",
+        "id": "1-0:1.7.0*255"
+      },
+      "measuredValue": {
+        "unit": "WATT",
+        "unitEncoded": 27,
+        "valueType": "Integer32",
+        "scale": 1,
+        "value": 0
+      }
+    },
+    {
+      "measurand": {
+        "name": "MA1",
+        "id": "1-0:0.0.0*255"
+      },
+      "measuredValue": {
+        "valueType": "String",
+        "value": "001BZR1521290137",
+        "valueEncoding": "UTF-8"
+      }
+    },
+    {
+      "measurand": {"name": "RCnt"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 102
+      }
+    },
+    {
+      "measurand": {"name": "OS"},
+      "measuredValue": {
+        "unit": "SECOND",
+        "unitEncoded": 7,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 1378630
+      }
+    },
+    {
+      "measurand": {"name": "Epoch"},
+      "measuredValue": {
+        "unit": "SECOND",
+        "unitEncoded": 7,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 1643620487
+      }
+    },
+    {
+      "measurand": {"name": "TZO"},
+      "measuredValue": {
+        "unit": "MIN",
+        "unitEncoded": 6,
+        "valueType": "Integer32",
+        "scale": 0,
+        "value": 60
+      }
+    },
+    {
+      "measurand": {"name": "EpochSetCnt"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 106
+      }
+    },
+    {
+      "measurand": {"name": "EpochSetOS"},
+      "measuredValue": {
+        "unit": "SECOND",
+        "unitEncoded": 7,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 1377968
+      }
+    },
+    {
+      "measurand": {"name": "DI"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 1
+      }
+    },
+    {
+      "measurand": {"name": "DO"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 0
+      }
+    },
+    {
+      "measurand": {"name": "Meta1"},
+      "measuredValue": {
+        "valueType": "String",
+        "value": "contract-id: rfid:6ba608c2",
+        "valueEncoding": "UTF-8"
+      }
+    },
+    {
+      "measurand": {"name": "Meta2"},
+      "measuredValue": {
+        "valueType": "String",
+        "value": "",
+        "valueEncoding": "UTF-8"
+      }
+    },
+    {
+      "measurand": {"name": "Meta3"},
+      "measuredValue": {
+        "valueType": "String",
+        "value": "csc-sw-version: v0.3.0-10-gd56f579",
+        "valueEncoding": "UTF-8"
+      }
+    },
+    {
+      "measurand": {"name": "Evt"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 0
+      }
+    }
+  ]
+}]
+}
+        

--- a/documentation/chargeIT2/20220131-csc-version-data.json
+++ b/documentation/chargeIT2/20220131-csc-version-data.json
@@ -1,0 +1,428 @@
+            {
+  "placeInfo" : {
+    "geoLocation" : {
+      "lat" : 0.0,
+      "lon" : 0.0
+    },
+    "address" : {
+      "street" : "Steigweg 24, Gebäude 94",
+      "town" : "Kitzingen",
+      "zipCode" : "97318"
+    },
+    "evseId" : "DE*BDO*E323455206*2"
+  },
+  "signedMeterValues" : [{
+  "signature": "3046022100f14ad89d059bf780f8afe69eb73428c85474b47dd0cd6f9d26207d8dd4b0c0ed02210097f9a58d557d3feb2d84cb5036483c86cf08c9c20a1d38ce469861f8a0d346f8",
+  "contract": {
+    "id": "6ba608c2",
+    "type": "rfid"
+  },
+  "meterInfo": {
+    "meterId": "001BZR1521290137",
+    "publicKey": "3059301306072a8648ce3d020106082a8648ce3d03010703420004dab8d78e67621823a1542b0e60175f62b5ef3230cf8d0fa0d52724acdb11cfdaa9aa170c0ca271b5adbbb7ba83bde301f67d77bd5000caf568ad2f4960320ad8",
+    "firmwareVersion": "1.9:32CA:AFF4, 6d1dd3c",
+    "type": "BSM-WS36A-H01-1311-0000",
+    "manufacturer": "BAUER Electronic"
+  },
+  "@id": "001BZR1521290137-101",
+  "time": "2022-01-31T10:13:33+01:00",
+  "@context": "https://www.chargeit-mobility.com/contexts/bsm-ws36a-json-v1",
+  "measurementId": 101,
+  "value": {
+    "measurand": {
+      "name": "RCR",
+      "id": "1-0:1.8.0*198"
+    },
+    "measuredValue": {
+      "unit": "WATT_HOUR",
+      "unitEncoded": 30,
+      "valueType": "UnsignedInteger32",
+      "scale": 0,
+      "value": 0
+    }
+  },
+  "additionalValues": [
+    {
+      "measurand": {"name": "Typ"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 1
+      }
+    },
+    {
+      "measurand": {
+        "name": "RCR",
+        "id": "1-0:1.8.0*198"
+      },
+      "measuredValue": {
+        "unit": "WATT_HOUR",
+        "unitEncoded": 30,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 0
+      }
+    },
+    {
+      "measurand": {
+        "name": "TotWhImp",
+        "id": "1-0:1.8.0*255"
+      },
+      "measuredValue": {
+        "unit": "WATT_HOUR",
+        "unitEncoded": 30,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 7200
+      }
+    },
+    {
+      "measurand": {
+        "name": "W",
+        "id": "1-0:1.7.0*255"
+      },
+      "measuredValue": {
+        "unit": "WATT",
+        "unitEncoded": 27,
+        "valueType": "Integer32",
+        "scale": 1,
+        "value": 0
+      }
+    },
+    {
+      "measurand": {
+        "name": "MA1",
+        "id": "1-0:0.0.0*255"
+      },
+      "measuredValue": {
+        "valueType": "String",
+        "value": "001BZR1521290137",
+        "valueEncoding": "UTF-8"
+      }
+    },
+    {
+      "measurand": {"name": "RCnt"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 101
+      }
+    },
+    {
+      "measurand": {"name": "OS"},
+      "measuredValue": {
+        "unit": "SECOND",
+        "unitEncoded": 7,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 1378556
+      }
+    },
+    {
+      "measurand": {"name": "Epoch"},
+      "measuredValue": {
+        "unit": "SECOND",
+        "unitEncoded": 7,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 1643620413
+      }
+    },
+    {
+      "measurand": {"name": "TZO"},
+      "measuredValue": {
+        "unit": "MIN",
+        "unitEncoded": 6,
+        "valueType": "Integer32",
+        "scale": 0,
+        "value": 60
+      }
+    },
+    {
+      "measurand": {"name": "EpochSetCnt"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 106
+      }
+    },
+    {
+      "measurand": {"name": "EpochSetOS"},
+      "measuredValue": {
+        "unit": "SECOND",
+        "unitEncoded": 7,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 1377968
+      }
+    },
+    {
+      "measurand": {"name": "DI"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 1
+      }
+    },
+    {
+      "measurand": {"name": "DO"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 0
+      }
+    },
+    {
+      "measurand": {"name": "Meta1"},
+      "measuredValue": {
+        "valueType": "String",
+        "value": "contract-id: rfid:6ba608c2",
+        "valueEncoding": "UTF-8"
+      }
+    },
+    {
+      "measurand": {"name": "Meta2"},
+      "measuredValue": {
+        "valueType": "String",
+        "value": "",
+        "valueEncoding": "UTF-8"
+      }
+    },
+    {
+      "measurand": {"name": "Meta3"},
+      "measuredValue": {
+        "valueType": "String",
+        "value": "csc-sw-version: v0.3.0-10-gd56f579",
+        "valueEncoding": "UTF-8"
+      }
+    },
+    {
+      "measurand": {"name": "Evt"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 0
+      }
+    }
+  ]
+}, {
+  "signature": "3045022055024952cccc23afcb4d0f24e75fa139486ca76c5969e680a2669ab611616bac022100fc1cff99ef5e95465a18dacafc141999085b96881395603623241415e2c42559",
+  "contract": {
+    "id": "6ba608c2",
+    "type": "rfid"
+  },
+  "meterInfo": {
+    "meterId": "001BZR1521290137",
+    "publicKey": "3059301306072a8648ce3d020106082a8648ce3d03010703420004dab8d78e67621823a1542b0e60175f62b5ef3230cf8d0fa0d52724acdb11cfdaa9aa170c0ca271b5adbbb7ba83bde301f67d77bd5000caf568ad2f4960320ad8",
+    "firmwareVersion": "1.9:32CA:AFF4, 6d1dd3c",
+    "type": "BSM-WS36A-H01-1311-0000",
+    "manufacturer": "BAUER Electronic"
+  },
+  "@id": "001BZR1521290137-102",
+  "time": "2022-01-31T10:14:47+01:00",
+  "@context": "https://www.chargeit-mobility.com/contexts/bsm-ws36a-json-v1",
+  "measurementId": 102,
+  "value": {
+    "measurand": {
+      "name": "RCR",
+      "id": "1-0:1.8.0*198"
+    },
+    "measuredValue": {
+      "unit": "WATT_HOUR",
+      "unitEncoded": 30,
+      "valueType": "UnsignedInteger32",
+      "scale": 0,
+      "value": 0
+    }
+  },
+  "additionalValues": [
+    {
+      "measurand": {"name": "Typ"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 2
+      }
+    },
+    {
+      "measurand": {
+        "name": "RCR",
+        "id": "1-0:1.8.0*198"
+      },
+      "measuredValue": {
+        "unit": "WATT_HOUR",
+        "unitEncoded": 30,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 0
+      }
+    },
+    {
+      "measurand": {
+        "name": "TotWhImp",
+        "id": "1-0:1.8.0*255"
+      },
+      "measuredValue": {
+        "unit": "WATT_HOUR",
+        "unitEncoded": 30,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 7200
+      }
+    },
+    {
+      "measurand": {
+        "name": "W",
+        "id": "1-0:1.7.0*255"
+      },
+      "measuredValue": {
+        "unit": "WATT",
+        "unitEncoded": 27,
+        "valueType": "Integer32",
+        "scale": 1,
+        "value": 0
+      }
+    },
+    {
+      "measurand": {
+        "name": "MA1",
+        "id": "1-0:0.0.0*255"
+      },
+      "measuredValue": {
+        "valueType": "String",
+        "value": "001BZR1521290137",
+        "valueEncoding": "UTF-8"
+      }
+    },
+    {
+      "measurand": {"name": "RCnt"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 102
+      }
+    },
+    {
+      "measurand": {"name": "OS"},
+      "measuredValue": {
+        "unit": "SECOND",
+        "unitEncoded": 7,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 1378630
+      }
+    },
+    {
+      "measurand": {"name": "Epoch"},
+      "measuredValue": {
+        "unit": "SECOND",
+        "unitEncoded": 7,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 1643620487
+      }
+    },
+    {
+      "measurand": {"name": "TZO"},
+      "measuredValue": {
+        "unit": "MIN",
+        "unitEncoded": 6,
+        "valueType": "Integer32",
+        "scale": 0,
+        "value": 60
+      }
+    },
+    {
+      "measurand": {"name": "EpochSetCnt"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 106
+      }
+    },
+    {
+      "measurand": {"name": "EpochSetOS"},
+      "measuredValue": {
+        "unit": "SECOND",
+        "unitEncoded": 7,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 1377968
+      }
+    },
+    {
+      "measurand": {"name": "DI"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 1
+      }
+    },
+    {
+      "measurand": {"name": "DO"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 0
+      }
+    },
+    {
+      "measurand": {"name": "Meta1"},
+      "measuredValue": {
+        "valueType": "String",
+        "value": "contract-id: rfid:6ba608c2",
+        "valueEncoding": "UTF-8"
+      }
+    },
+    {
+      "measurand": {"name": "Meta2"},
+      "measuredValue": {
+        "valueType": "String",
+        "value": "",
+        "valueEncoding": "UTF-8"
+      }
+    },
+    {
+      "measurand": {"name": "Meta3"},
+      "measuredValue": {
+        "valueType": "String",
+        "value": "csc-sw-version: v0.3.0-10-gd56f579",
+        "valueEncoding": "UTF-8"
+      }
+    },
+    {
+      "measurand": {"name": "Evt"},
+      "measuredValue": {
+        "unit": "UNITLESS",
+        "unitEncoded": 255,
+        "valueType": "UnsignedInteger32",
+        "scale": 0,
+        "value": 0
+      }
+    }
+  ]
+}]
+}
+        

--- a/src/ts/BSMCrypt01.ts
+++ b/src/ts/BSMCrypt01.ts
@@ -101,7 +101,7 @@ export class BSMCrypt01 extends ACrypt {
 
     //#region tryToParseBSM_WS36aMeasurements(Measurements)
 
-    public async tryToParseBSM_WS36aMeasurements(CTR: chargyInterfaces.IChargeTransparencyRecord, EVSEId: String, CSCSWVersion: String, Measurements: Array<any>) : Promise<chargyInterfaces.IChargeTransparencyRecord|chargyInterfaces.ISessionCryptoResult>
+    public async tryToParseBSM_WS36aMeasurements(CTR: chargyInterfaces.IChargeTransparencyRecord, EVSEId: String, ExpectedCscSwVersion: string|null, Measurements: Array<any>) : Promise<chargyInterfaces.IChargeTransparencyRecord|chargyInterfaces.ISessionCryptoResult>
     {
 
         if (!Array.isArray(Measurements) || Measurements.length < 2) return {
@@ -476,6 +476,8 @@ export class BSMCrypt01 extends ACrypt {
             let previousOS              = -1;
             let previousEpoch           = -1;
 
+	    let previousCscSwVersion: string|null = null;
+
             //#endregion
 
             for (const currentMeasurement of Measurements)
@@ -703,11 +705,19 @@ export class BSMCrypt01 extends ACrypt {
 
                     const csc_sw_version = (signedCSCSWVersion[0].measuredValue.value as String).replace('csc-sw-version:', '').trim();
 
-                    if (csc_sw_version !== 'unknown' && CSCSWVersion !== csc_sw_version)
+                    if (ExpectedCscSwVersion !== null && ExpectedCscSwVersion !== csc_sw_version)
+                        return {
+                            status:   chargyInterfaces.SessionVerificationResult.InvalidSessionFormat,
+                            message:  "Unexpected charging station controller software version!"
+                        };
+
+                    if (previousCscSwVersion !== null && previousCscSwVersion !== csc_sw_version)
                         return {
                             status:   chargyInterfaces.SessionVerificationResult.InvalidSessionFormat,
                             message:  "Inconsistent charging station controller software version!"
                         };
+
+                    previousCscSwVersion = csc_sw_version;
 
                 }
 

--- a/src/ts/chargeIT.ts
+++ b/src/ts/chargeIT.ts
@@ -327,7 +327,7 @@ export class ChargeIT {
 
                     if (signedMeterValueContext === "https://www.chargeit-mobility.com/contexts/bsm-ws36a-json-v0" ||
                         signedMeterValueContext === "https://www.chargeit-mobility.com/contexts/bsm-ws36a-json-v1") {
-                        return await new BSMCrypt01(this.chargy).tryToParseBSM_WS36aMeasurements(CTR, evseId, "", signedMeterValues);
+                        return await new BSMCrypt01(this.chargy).tryToParseBSM_WS36aMeasurements(CTR, evseId, null, signedMeterValues);
                     }
 
                     else if (signedMeterValueContext.startsWith("ALFEN")) {


### PR DESCRIPTION
* There is an issue with checking the controller software version in https://github.com/OpenChargingCloud/ChargyDesktopApp/commit/a21ee7793f5b731dbfd68b97bc520a0cf5d63faa
    * The software version is always checked against the one supplied as `CSCSWVersion` to [`tryToParseBSM_WS36aMeasurements`](https://github.com/OpenChargingCloud/ChargyDesktopApp/blob/a21ee7793f5b731dbfd68b97bc520a0cf5d63faa/src/ts/BSMCrypt01.ts#L104)
    * Chargy always passed an empty string there
    * So the check failed in cases where a actual software version was set (which was not covered by the test data so far)

* This PR fixes the check for the changing controller software version for BSM-WS36A data
    * Check that the software version is consistent across measurments
    * The parameter is made the expected software version
        * Using `null` for not expecting a certain software version
        * If specified, the software version from the measurements needs to match

* Test data is provided in analog to #66
* This PR also includes removing the JavaScript bundle generated by `webpack` from version control