### PR TITLE
Fix scale factor usage and measurement ID comparison for BSM-WS36A

### DIFF
--- a/documentation/chargeIT2/bsm-ws36a-good-with-non-zero-scale-factors.json
+++ b/documentation/chargeIT2/bsm-ws36a-good-with-non-zero-scale-factors.json
@@ -1,0 +1,469 @@
+{
+  "@context": "https://www.chargeit-mobility.com/contexts/charging-station-json-v1",
+  "@id": "b4033219-96de-49a2-99ec-f6577d36f106",
+  "chargePointInfo": {
+    "placeInfo": {
+      "geoLocation": {
+        "lat": 48.03552,
+        "lon": 10.50669
+      },
+      "address": {
+        "street": "Breitenbergstr. 2",
+        "town": "Mindelheim",
+        "zipCode": "87719"
+      }
+    },
+    "evseId": "DE*BDO*E8025334492*2"
+  },
+  "chargingStationInfo": {
+    "manufacturer": "chargeIT mobility GmbH",
+    "type": "CIT Lades\u00e4ule online",
+    "serialNumber": "2020-24-T-042",
+    "controllerSoftwareVersion": "v1.2.34",
+    "compliance": "See https://www.chargeit-mobility.com/wp-content/uploads/chargeIT-Baumusterpr%C3%BCfbescheinigung-Lades%C3%A4ule-Online.pdf for type examination certificate"
+  },
+  "signedMeterValues": [
+    {
+      "@context": "https://www.chargeit-mobility.com/contexts/bsm-ws36a-json-v1",
+      "@id": "001BZR1521070006-134",
+      "time": "2022-06-15T14:38:56+02:00",
+      "meterInfo": {
+        "firmwareVersion": "1.9:32CA:AFF4, 38a6a90-dirty",
+        "publicKey": "3059301306072a8648ce3d020106082a8648ce3d030107034200044bfd02c1d85272ceea9977db26d72cc401d9e5602faeee7ec7b6b62f9c0cce34ad8d345d5ac0e8f65deb5ff0bb402b1b87926bd1b7fc2dbc3a9774e8e70c7254",
+        "meterId": "001BZR1521070006",
+        "manufacturer": "BAUER Electronic",
+        "type": "BSM-WS36A-H01-1311-0000"
+      },
+      "contract": {
+        "id": "12345678abcdef",
+        "type": "rfid"
+      },
+      "measurementId": 134,
+      "value": {
+        "measurand": {
+          "id": "1-0:1.8.0*198",
+          "name": "RCR"
+        },
+        "measuredValue": {
+          "scale": 1,
+          "unit": "WATT_HOUR",
+          "unitEncoded": 30,
+          "value": 0,
+          "valueType": "UnsignedInteger32"
+        }
+      },
+      "additionalValues": [
+        {
+          "measurand": {
+            "name": "Typ"
+          },
+          "measuredValue": {
+            "unitEncoded": 255,
+            "value": 1,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "id": "1-0:1.8.0*198",
+            "name": "RCR"
+          },
+          "measuredValue": {
+            "scale": 1,
+            "unit": "WATT_HOUR",
+            "unitEncoded": 30,
+            "value": 0,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "id": "1-0:1.8.0*255",
+            "name": "TotWhImp"
+          },
+          "measuredValue": {
+            "scale": 1,
+            "unit": "WATT_HOUR",
+            "unitEncoded": 30,
+            "value": 7803,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "id": "1-0:1.7.0*255",
+            "name": "W"
+          },
+          "measuredValue": {
+            "scale": 1,
+            "unit": "WATT",
+            "unitEncoded": 27,
+            "value": 0,
+            "valueType": "Integer32"
+          }
+        },
+        {
+          "measurand": {
+            "id": "1-0:0.0.0*255",
+            "name": "MA1"
+          },
+          "measuredValue": {
+            "scale": 0,
+            "value": "001BZR1521070006",
+            "valueType": "String",
+            "valueEncoding": "ISO-8859-1"
+          }
+        },
+        {
+          "measurand": {
+            "name": "RCnt"
+          },
+          "measuredValue": {
+            "unitEncoded": 255,
+            "value": 134,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "name": "OS"
+          },
+          "measuredValue": {
+            "unit": "SECOND",
+            "unitEncoded": 7,
+            "value": 4955,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "name": "Epoch"
+          },
+          "measuredValue": {
+            "unit": "SECOND",
+            "unitEncoded": 7,
+            "value": 1655296736,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "name": "TZO"
+          },
+          "measuredValue": {
+            "unit": "MINUTE",
+            "unitEncoded": 6,
+            "value": 120,
+            "valueType": "Integer32"
+          }
+        },
+        {
+          "measurand": {
+            "name": "EpochSetCnt"
+          },
+          "measuredValue": {
+            "unitEncoded": 255,
+            "value": 91,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "name": "EpochSetOS"
+          },
+          "measuredValue": {
+            "unit": "SECOND",
+            "unitEncoded": 7,
+            "value": 4431,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "name": "DI"
+          },
+          "measuredValue": {
+            "unitEncoded": 255,
+            "value": 1,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "name": "DO"
+          },
+          "measuredValue": {
+            "unitEncoded": 255,
+            "value": 0,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "name": "Meta1"
+          },
+          "measuredValue": {
+            "scale": 0,
+            "value": "contract-id: rfid:12345678abcdef",
+            "valueType": "String",
+            "valueEncoding": "ISO-8859-1"
+          }
+        },
+        {
+          "measurand": {
+            "name": "Meta2"
+          },
+          "measuredValue": {
+            "scale": 0,
+            "value": "evse-id: DE*BDO*E8025334492*2",
+            "valueType": "String",
+            "valueEncoding": "ISO-8859-1"
+          }
+        },
+        {
+          "measurand": {
+            "name": "Meta3"
+          },
+          "measuredValue": {
+            "scale": 0,
+            "value": "csc-sw-version: v1.2.34",
+            "valueType": "String",
+            "valueEncoding": "ISO-8859-1"
+          }
+        },
+        {
+          "measurand": {
+            "name": "Evt"
+          },
+          "measuredValue": {
+            "unitEncoded": 255,
+            "value": 0,
+            "valueType": "UnsignedInteger32"
+          }
+        }
+      ],
+      "signature": "304502205f94a566628fc83f59b570bcad11b298d5695e72aab2f5704de8d90ea6daa965022100b433db9bae11de0b5c286081c79167f0ec34a45d15f6d2d459488d2f49b9b1da"
+    },
+    {
+      "@context": "https://www.chargeit-mobility.com/contexts/bsm-ws36a-json-v1",
+      "@id": "001BZR1521070006-135",
+      "time": "2022-06-15T14:40:02+02:00",
+      "meterInfo": {
+        "firmwareVersion": "1.9:32CA:AFF4, 38a6a90-dirty",
+        "publicKey": "3059301306072a8648ce3d020106082a8648ce3d030107034200044bfd02c1d85272ceea9977db26d72cc401d9e5602faeee7ec7b6b62f9c0cce34ad8d345d5ac0e8f65deb5ff0bb402b1b87926bd1b7fc2dbc3a9774e8e70c7254",
+        "meterId": "001BZR1521070006",
+        "manufacturer": "BAUER Electronic",
+        "type": "BSM-WS36A-H01-1311-0000"
+      },
+      "contract": {
+        "id": "12345678abcdef",
+        "type": "rfid"
+      },
+      "measurementId": 135,
+      "value": {
+        "measurand": {
+          "id": "1-0:1.8.0*198",
+          "name": "RCR"
+        },
+        "measuredValue": {
+          "scale": 1,
+          "unit": "WATT_HOUR",
+          "unitEncoded": 30,
+          "value": 3,
+          "valueType": "UnsignedInteger32"
+        }
+      },
+      "additionalValues": [
+        {
+          "measurand": {
+            "name": "Typ"
+          },
+          "measuredValue": {
+            "unitEncoded": 255,
+            "value": 2,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "id": "1-0:1.8.0*198",
+            "name": "RCR"
+          },
+          "measuredValue": {
+            "scale": 1,
+            "unit": "WATT_HOUR",
+            "unitEncoded": 30,
+            "value": 3,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "id": "1-0:1.8.0*255",
+            "name": "TotWhImp"
+          },
+          "measuredValue": {
+            "scale": 1,
+            "unit": "WATT_HOUR",
+            "unitEncoded": 30,
+            "value": 7806,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "id": "1-0:1.7.0*255",
+            "name": "W"
+          },
+          "measuredValue": {
+            "scale": 1,
+            "unit": "WATT",
+            "unitEncoded": 27,
+            "value": 0,
+            "valueType": "Integer32"
+          }
+        },
+        {
+          "measurand": {
+            "id": "1-0:0.0.0*255",
+            "name": "MA1"
+          },
+          "measuredValue": {
+            "scale": 0,
+            "value": "001BZR1521070006",
+            "valueType": "String",
+            "valueEncoding": "ISO-8859-1"
+          }
+        },
+        {
+          "measurand": {
+            "name": "RCnt"
+          },
+          "measuredValue": {
+            "unitEncoded": 255,
+            "value": 135,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "name": "OS"
+          },
+          "measuredValue": {
+            "unit": "SECOND",
+            "unitEncoded": 7,
+            "value": 5021,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "name": "Epoch"
+          },
+          "measuredValue": {
+            "unit": "SECOND",
+            "unitEncoded": 7,
+            "value": 1655296802,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "name": "TZO"
+          },
+          "measuredValue": {
+            "unit": "MINUTE",
+            "unitEncoded": 6,
+            "value": 120,
+            "valueType": "Integer32"
+          }
+        },
+        {
+          "measurand": {
+            "name": "EpochSetCnt"
+          },
+          "measuredValue": {
+            "unitEncoded": 255,
+            "value": 91,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "name": "EpochSetOS"
+          },
+          "measuredValue": {
+            "unit": "SECOND",
+            "unitEncoded": 7,
+            "value": 4431,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "name": "DI"
+          },
+          "measuredValue": {
+            "unitEncoded": 255,
+            "value": 1,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "name": "DO"
+          },
+          "measuredValue": {
+            "unitEncoded": 255,
+            "value": 0,
+            "valueType": "UnsignedInteger32"
+          }
+        },
+        {
+          "measurand": {
+            "name": "Meta1"
+          },
+          "measuredValue": {
+            "scale": 0,
+            "value": "contract-id: rfid:12345678abcdef",
+            "valueType": "String",
+            "valueEncoding": "ISO-8859-1"
+          }
+        },
+        {
+          "measurand": {
+            "name": "Meta2"
+          },
+          "measuredValue": {
+            "scale": 0,
+            "value": "evse-id: DE*BDO*E8025334492*2",
+            "valueType": "String",
+            "valueEncoding": "ISO-8859-1"
+          }
+        },
+        {
+          "measurand": {
+            "name": "Meta3"
+          },
+          "measuredValue": {
+            "scale": 0,
+            "value": "csc-sw-version: v1.2.34",
+            "valueType": "String",
+            "valueEncoding": "ISO-8859-1"
+          }
+        },
+        {
+          "measurand": {
+            "name": "Evt"
+          },
+          "measuredValue": {
+            "unitEncoded": 255,
+            "value": 0,
+            "valueType": "UnsignedInteger32"
+          }
+        }
+      ],
+      "signature": "3044022008dd174e5cc7e1d5e6971f1b62e73708723b38e4c28de2356a20ef2806ee61fa02200f1bad7b28bea3479a2c63ddebd45eccabb1f4d0015eee28a3545a1d9e5ebe18"
+    }
+  ]
+}

--- a/src/ts/BSMCrypt01.ts
+++ b/src/ts/BSMCrypt01.ts
@@ -494,13 +494,30 @@ export class BSMCrypt01 extends ACrypt {
                         message:  "Inconsistent @context!"
                     };
 
+                let currentId = currentMeasurement["@id"];
+                if (previousId !== "")
+                {
+                    // IDs from the BSM-WS36A are in the form of "PREFIX-COUNTER". Check that prefixes
+                    // match match and the counters are stricly increasing.
 
-                if (previousId !== "" && currentMeasurement["@id"] <= previousId)
-                    return {
-                        status:   chargyInterfaces.SessionVerificationResult.InvalidSessionFormat,
-                        message:  "Inconsistent measurement identifications!"
-                    };
-                previousId   = currentMeasurement["@id"];
+                    let previousParts = previousId.split("-");
+                    let currentParts = currentId.split("-");
+
+                    if (previousParts.length !== 2
+                        || previousParts.length !== currentParts.length
+                        || previousParts[0] !== currentParts[0]
+                        // parseInt returns NaN in case parsing fails which in turn does not match
+                        // anything (not even NaN). This way we are checking that both counter values
+                        // are numeric too.
+                        || parseInt(previousParts[1], 10) >= parseInt(currentParts[1], 10))
+                    {
+                        return {
+                            status:   chargyInterfaces.SessionVerificationResult.InvalidSessionFormat,
+                            message:  "Inconsistent measurement identifications!"
+                        };
+                    }
+                }
+                previousId = currentId;
 
 
                 if (previousTime !== "" && currentMeasurement.time <= previousTime)

--- a/src/ts/BSMCrypt01.ts
+++ b/src/ts/BSMCrypt01.ts
@@ -25,8 +25,11 @@ export interface IBSMMeasurementValue extends chargyInterfaces.IMeasurementValue
 {
     Typ:                        number,
     RCR:                        number,
+    RCR_SF:                     number,
     TotWhImp:                   number,
+    TotWhImp_SF:                number,
     W:                          number,
+    W_SF:                       number,
     MA1:                        string,
     RCnt:                       number,
     OS:                         number,
@@ -973,8 +976,11 @@ export class BSMCrypt01 extends ACrypt {
                     Typ:           dataSet.Typ,
                     value:         dataSet.value,
                     RCR:           dataSet.RCR[4],
+                    RCR_SF:        dataSet.RCR[1],
                     TotWhImp:      dataSet.TotWhImp[4],
+                    TotWhImp_SF:   dataSet.TotWhImp[1],
                     W:             dataSet.W[4],
+                    W_SF:          dataSet.W[1],
                     MA1:           dataSet.MA1,
                     RCnt:          dataSet.RCnt,
                     OS:            dataSet.OS,
@@ -1349,13 +1355,17 @@ export class BSMCrypt01 extends ACrypt {
         let buffer        = new ArrayBuffer(requiredSize);
         var cryptoBuffer  = new DataView(buffer);
 
+        // TODO: Factor out creating IBSMCrypt01Result from IBSMMeasurementValue.
+        //
+        // TODO: Use units and scale factors from input data instead of making
+        // assumptions about them.
         var cryptoResult:IBSMCrypt01Result = {
             status:        chargyInterfaces.VerificationResult.InvalidSignature,
             ArraySize:     requiredSize,
             Typ:           chargyLib.SetUInt32_withCode(cryptoBuffer, measurementValue.Typ,          0, 255,   0),
-            RCR:           chargyLib.SetUInt32_withCode(cryptoBuffer, measurementValue.RCR,          0,  30,   6),
-            TotWhImp:      chargyLib.SetUInt32_withCode(cryptoBuffer, measurementValue.TotWhImp,     0,  30,  12),
-            W:             chargyLib.SetUInt32_withCode(cryptoBuffer, measurementValue.W,            1,  27,  18),
+            RCR:           chargyLib.SetUInt32_withCode(cryptoBuffer, measurementValue.RCR,          measurementValue.RCR_SF,  30,   6),
+            TotWhImp:      chargyLib.SetUInt32_withCode(cryptoBuffer, measurementValue.TotWhImp,     measurementValue.TotWhImp_SF,  30,  12),
+            W:             chargyLib.SetUInt32_withCode(cryptoBuffer, measurementValue.W,            measurementValue.W_SF,  27,  18),
             MA1:           chargyLib.SetText_withLength(cryptoBuffer, measurementValue.MA1,                   24),
             RCnt:          chargyLib.SetUInt32_withCode(cryptoBuffer, measurementValue.RCnt,         0, 255,  24 + MA1_length),
             OS:            chargyLib.SetUInt32_withCode(cryptoBuffer, measurementValue.OS,           0,   7,  30 + MA1_length),
@@ -1516,13 +1526,15 @@ export class BSMCrypt01 extends ACrypt {
         let buffer        = new ArrayBuffer(requiredSize);
         let cryptoBuffer  = new DataView(buffer);
 
+        // TODO: Use units and scale factors from input data instead of making
+        // assumptions about them.
         let cryptoResult:IBSMCrypt01Result = {
             status:        chargyInterfaces.VerificationResult.InvalidSignature,
             ArraySize:     requiredSize,
             Typ:           chargyLib.SetUInt32_withCode(cryptoBuffer, measurementValue.Typ,          0, 255,   0),
-            RCR:           chargyLib.SetUInt32_withCode(cryptoBuffer, measurementValue.RCR,          0,  30,   6),
-            TotWhImp:      chargyLib.SetUInt32_withCode(cryptoBuffer, measurementValue.TotWhImp,     0,  30,  12),
-            W:             chargyLib.SetUInt32_withCode(cryptoBuffer, measurementValue.W,            1,  27,  18),
+            RCR:           chargyLib.SetUInt32_withCode(cryptoBuffer, measurementValue.RCR,          measurementValue.RCR_SF,  30,   6),
+            TotWhImp:      chargyLib.SetUInt32_withCode(cryptoBuffer, measurementValue.TotWhImp,     measurementValue.TotWhImp_SF,  30,  12),
+            W:             chargyLib.SetUInt32_withCode(cryptoBuffer, measurementValue.W,            measurementValue.W_SF,  27,  18),
             MA1:           chargyLib.SetText_withLength(cryptoBuffer, measurementValue.MA1,                   24),
             RCnt:          chargyLib.SetUInt32_withCode(cryptoBuffer, measurementValue.RCnt,         0, 255,  24 + MA1_length),
             OS:            chargyLib.SetUInt32_withCode(cryptoBuffer, measurementValue.OS,           0,   7,  30 + MA1_length),
@@ -1679,8 +1691,8 @@ export class BSMCrypt01 extends ACrypt {
             // https://github.com/chargeITmobility/bsm-python-private/blob/30abc7ba958c936fdb952ed1f121e45d0818419c/doc/examples/snapshots.md#verifying-a-snapshot-with-the-bsm-tool
 
             this.CreateLine("Snapshot-Typ", this.ParseTyp(measurementValue.Typ),                 result.Typ         || "", infoDiv, PlainTextDiv);
-            this.CreateLine("RCR",          measurementValue.RCR + " Wh",                        result.RCR         || "", infoDiv, PlainTextDiv);
-            this.CreateLine("TotWhImp",     measurementValue.TotWhImp + " Wh",                   result.TotWhImp    || "", infoDiv, PlainTextDiv);
+            this.CreateLine("RCR",          measurementValue.RCR * 10 + " Wh",                   result.RCR         || "", infoDiv, PlainTextDiv);
+            this.CreateLine("TotWhImp",     measurementValue.TotWhImp * 10 + " Wh",              result.TotWhImp    || "", infoDiv, PlainTextDiv);
             this.CreateLine("W",            measurementValue.W + " Watt",                        result.W           || "", infoDiv, PlainTextDiv);
             this.CreateLine("MA1",          measurementValue.MA1,                                result.MA1         || "", infoDiv, PlainTextDiv);
             this.CreateLine("RCnt",         measurementValue.RCnt,                               result.RCnt        || "", infoDiv, PlainTextDiv);


### PR DESCRIPTION
* We are about to change de default scale factors for energy values
    * The assumption for them being zero no longer holds
    * Using the actual scale factors from the signed data ensures that the existing and new format is handled correctly by Chargy

* Interpret measurement IDs for consistency checks
     * They are composed of a prefix and a counter (the latter without leading zeroes)
     * So a lexical comparison fails in case that the conter overflows to a new decimal digit
     * For example `PREFIX-9` to `PREFIX-10` where the latter is considered smaller than the former
     * Individually comparing the ID components sorts this out