### PR TITLE
Fix Nightly installer publishing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -114,7 +114,7 @@ jobs:
         run: npm ci
 
       - name: Build ${{ matrix.target }} distributions
-        run: npm run build -- --${{ matrix.target }}
+        run: npm run build -- --${{ matrix.target }} --publish never
         env:
           # Signing and notarization belong in a separate release workflow with
           # protected secrets. Nightly validates reproducible unsigned output.


### PR DESCRIPTION
## Summary
- disable electron-builder's implicit CI publishing in Nightly installer jobs
- keep installer output delivery through actions/upload-artifact

## Verification
- parsed .github/workflows/nightly.yml successfully
- reproduced the Windows build with CI=true and confirmed electron-builder exits successfully without requiring GH_TOKEN