### PR TITLE
Generate SBOM from package lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "vitest run --config tests/vitest.config.ts",
     "test:typecheck": "tsc -p tests/tsconfig.json --noEmit",
     "test:watch": "vitest --config tests/vitest.config.ts",
-    "sbom": "cyclonedx-npm --output-format json --output-file sbom.json",
+    "sbom": "cyclonedx-npm --package-lock-only --output-format json --output-file sbom.json",
     "bundle": "webpack -c webpack.config.cjs",
     "build": "npm run sbom && npm run bundle && electron-builder",
     "pack": "npm run sbom && npm run bundle && electron-builder --dir",


### PR DESCRIPTION
## Summary
- generate the SBOM from package-lock.json instead of inspecting node_modules
- avoid failures caused by the optional native libxmljs2 dependency on Windows/Node 26

## Verification
- generated and parsed a CycloneDX SBOM with --package-lock-only